### PR TITLE
fixed missing closing tag on ArSpaceBook

### DIFF
--- a/pages/ArSpaceBook.vue
+++ b/pages/ArSpaceBook.vue
@@ -356,6 +356,7 @@
 			prev=""
 		/>
 	</div>
+	</div>
 </template>
 
 <script>


### PR DESCRIPTION
This was actually the only closing tag I found that was affecting the build. 